### PR TITLE
fix compiler warning

### DIFF
--- a/plugins/telnet/telnetTunnel.c
+++ b/plugins/telnet/telnetTunnel.c
@@ -35,7 +35,7 @@ int eInit(int fd)
 
 	  if (pf != NULL) {
 
-	    while (fgets (bf, 200, pf) > 0) {
+	    while (fgets (bf, 200, pf) != NULL) {
 	      if (strstr (bf, "dCap_Username = ")) {
 		bf[strlen(bf)-1] = 0;
 		user = strdup (bf + strlen ("dCap_Username = "));


### PR DESCRIPTION
fgets return type is (char *) and returns either the buffer or NULL on error.
The code looks as it is expecting that an integer is returned with -1
representing an error.  This triggers a warning with gcc's -Wpedantic enabled
(see ticket).

This patch checks whether returned value is NULL.

Ticket: http://rt.dcache.org/Ticket/Display.html?id=8319
