### PR TITLE
dCap Fedora spec

### DIFF
--- a/specs/sl6/dcap-fedora.spec
+++ b/specs/sl6/dcap-fedora.spec
@@ -124,9 +124,45 @@ rm -rf %{buildroot}
 make %{?_smp_mflags} check
 %endif
 
-%post libs -p /sbin/ldconfig
+%post tunnel-telnet
+cat >/etc/ld.so.conf.d/dcap-tunnel-telnet.conf <<EOF
+%{_libdir}/%{name}
+EOF
+/sbin/ldconfig
 
-%postun libs -p /sbin/ldconfig
+%post tunnel-ssl
+cat >/etc/ld.so.conf.d/dcap-tunnel-ssl.conf <<EOF
+%{_libdir}/%{name}
+EOF
+/sbin/ldconfig
+
+%post tunnel-krb
+cat >/etc/ld.so.conf.d/dcap-tunnel-krb.conf <<EOF
+%{_libdir}/%{name}
+EOF
+/sbin/ldconfig
+
+%post tunnel-gsi
+cat >/etc/ld.so.conf.d/dcap-tunnel-gsi.conf <<EOF
+%{_libdir}/%{name}
+EOF
+/sbin/ldconfig
+
+%postun tunnel-telnet
+rm /etc/ld.so.conf.d/dcap-tunnel-telnet.conf
+/sbin/ldconfig
+
+%postun tunnel-ssl
+rm /etc/ld.so.conf.d/dcap-tunnel-ssl.conf
+/sbin/ldconfig
+
+%postun tunnel-krb
+rm /etc/ld.so.conf.d/dcap-tunnel-krb.conf
+/sbin/ldconfig
+
+%postun tunnel-gsi
+rm /etc/ld.so.conf.d/dcap-tunnel-gsi.conf
+/sbin/ldconfig
 
 # Redefine license as doc for old rpm versions (EPEL 5 and 6)
 %{!?_licensedir: %global license %%doc}


### PR DESCRIPTION
=====

The Fedora spec file install all tunnel libraries to /usr/lib64/dcap which results in

[root@vm-dcache-deploy3 x86_64]# dccp /etc/group gsidcap://prometheus.desy.de:22128/VOs/desy/dccpTest00000002
Failed to add IO tunnel (/usr/lib64/libgsiTunnel.so: cannot open shared object file: No such file or directory). Provider: [libgsiTunnel.so].

when running a dccp with e.g. the gsi tunnel.

This patch fixes this by creating one file per tunnel like so:  /etc/ld.so.conf.d/dcap-tunnel-<tunnel name>.conf

On deleting the package the file is cleanedup and ldconfig is executed to update the library cache.