### PR TITLE
Make configure work with openssl 1.1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -164,7 +164,7 @@ AC_CHECK_HEADERS([openssl/err.h], [], [nossl=1])
 if test "${nossl}" != "0" ; then
 AC_MSG_RESULT([Disabling ssl plugin as header files not found.])
 else
-AC_CHECK_LIB(ssl,SSL_library_init,[
+AC_CHECK_LIB(ssl,SSL_write,[
 SSL_LIBS="-lssl"
 ],[
 nossl=1


### PR DESCRIPTION
The dcap configure scripts fails to detect the openssl library after updating to openssl 1.1.0.
The reason is that SSL_library_init is no longer a proper symbol in the library, but is only defined as a macro in the headers.
By modifying the test to check for SSL_write instead it works.
