### PR TITLE
Don't use deprecated TLSv1_client_method

### DIFF
--- a/plugins/ssl/sslTunnel.c
+++ b/plugins/ssl/sslTunnel.c
@@ -56,7 +56,8 @@ int eInit(int fd)
 		++initialized;
 	}
 
-	ssl_ctx = SSL_CTX_new(TLSv1_client_method());
+	ssl_ctx = SSL_CTX_new(SSLv23_client_method());
+	SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 	ssl_con = (SSL *) SSL_new(ssl_ctx);
 
 	ret = SSL_set_fd(ssl_con, fd);


### PR DESCRIPTION
See the bug report in Debian BTS for details:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=871428
