### PR TITLE
Allow building on RHEL 6 (automake 1.11.1)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_SUBST(LIBRARY_VERSION)
 AC_CANONICAL_HOST
 
 AC_PROG_CC
-AM_PROG_AR
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
 LT_INIT([shared,disable-static])
 


### PR DESCRIPTION
AM_PROG_AR was introduced in automake 1.11.2. Make its use conditional to allow building on RHEL 6 that has automake 1.11.1.
