### PR TITLE
Missing declaration

### DIFF
--- a/src/dcap.c
+++ b/src/dcap.c
@@ -119,6 +119,7 @@ static int get_data_socket();
 static int ascii_open_conversation(struct vsp_node *);
 static int getDataMessage(struct vsp_node *);
 static void getRevision( revision * );
+static void freeRevision( revision * );
 static int init_hostname();
 static void getPortRange();
 static int isActive();


### PR DESCRIPTION
```
dcap.c:774:2: warning: implicit declaration of function 'freeRevision'; did you mean 'getRevision'? [-Wimplicit-function-declaration]
  freeRevision(&rev);
dcap.c:1962:6: warning: conflicting types for 'freeRevision'
 void freeRevision( revision *rev )
dcap.c:774:2: note: previous implicit declaration of 'freeRevision' was here
  freeRevision(&rev);
```