### PR TITLE
Fix build failure when ntohll and htonll are macros

### DIFF
--- a/src/dcap.c
+++ b/src/dcap.c
@@ -127,10 +127,11 @@ static ConfirmationBlock get_reply(int);
 static int name_invalid(char *);
 static server * url2srv(dcap_url *);
 
-#ifndef HAVE_HTONLL
+#if !defined(HAVE_HTONLL) && !defined(htonll)
     uint64_t  htonll(uint64_t);
 #endif
-#ifndef HAVE_NTOHLL
+
+#if !defined(HAVE_NTOHLL) && !defined(ntohll)
     uint64_t  ntohll(uint64_t);
 #endif
 
@@ -1631,7 +1632,7 @@ get_fin(struct vsp_node * node)
 #  error Unknown Byte order
 #endif
 
-#ifndef HAVE_NTOHLL
+#if !defined(HAVE_NTOHLL) && !defined(ntohll)
     uint64_t
     ntohll(uint64_t x)
     {
@@ -1641,15 +1642,15 @@ get_fin(struct vsp_node * node)
         return x;
     #endif /* I_AM_LITTLE_ENDIAN */
     }
-#endif /* HAVE_NTOHLL */
+#endif /* HAVE_NTOHLL ntohll */
 
-#ifndef HAVE_HTONLL
+#if !defined(HAVE_HTONLL) && !defined(htonll) 
     uint64_t
     htonll(uint64_t arg)
     {
         return ntohll(arg);
     }
-#endif /* HAVE_HTONLL */
+#endif /* HAVE_HTONLL htonll */
 
 void dc_setReplyHostName(const char *s)
 {

--- a/src/dcap.c
+++ b/src/dcap.c
@@ -127,14 +127,6 @@ static ConfirmationBlock get_reply(int);
 static int name_invalid(char *);
 static server * url2srv(dcap_url *);
 
-#if !defined(HAVE_HTONLL) && !defined(htonll)
-    uint64_t  htonll(uint64_t);
-#endif
-
-#if !defined(HAVE_NTOHLL) && !defined(ntohll)
-    uint64_t  ntohll(uint64_t);
-#endif
-
 static MUTEX(couterLock);
 static unsigned int connectionCounter = 0;
 static unsigned int newCounter();

--- a/src/dcap_functions.h
+++ b/src/dcap_functions.h
@@ -39,10 +39,14 @@ int get_fin( struct vsp_node *);
 int get_ack(int , ConfirmationBlock * );
 
 
-#ifndef HAVE_NTOHLL
+// Declare the function if not defined by the system
+// as eithter a function or a macro
+// Darwin Libsystem may #define ntohll as a parameterized macro
+#if !defined(HAVE_NTOHLL) && !defined(ntohll)
 uint64_t ntohll(uint64_t x);
-#endif /* HAVE_NTOHLL */
+#endif /* HAVE_NTOHLL ntohll */
 
-#ifndef HAVE_HTONLL
+// Same as above`
+#if !defined(HAVE_HTONLL) && !defined(htonll)
 uint64_t htonll(uint64_t arg);
-#endif /* HAVE_HTONLL */
+#endif /* HAVE_HTONLL htonll */


### PR DESCRIPTION
On Darwin (Mac OS) Libsystem, `ntohll` and `htonll` has been `#define`d as parameterized macro instead of functions

Fix by examine if `ntohll` and `htonll` are `#defined` using `#ifndef`. If defined as macros, the declarations and definitions will be skipped.

Closes #21 