### PR TITLE
Clarify that license is LGPL

### DIFF
--- a/plugins/gssapi/Copyright
+++ b/plugins/gssapi/Copyright
@@ -2,8 +2,8 @@
        Copyright (c) 2000,2001,2002 DESY Hamburg DMG-Division
                All rights reserved.
 
-       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
-                 DESY Hamburg DMG-Division
+   This program can be distributed under the terms of the GNU LGPL.
+   See the file COPYING.LIB
 
 
 ============================================================================

--- a/plugins/gssapi/gssIoTunnel.c
+++ b/plugins/gssapi/gssIoTunnel.c
@@ -6,10 +6,10 @@
  *       Copyright (c) 2000,2001,2002 DESY Hamburg DMG-Division
  *               All rights reserved.
  *
- *       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
- *                 DESY Hamburg DMG-Division
+ *   This program can be distributed under the terms of the GNU LGPL.
+ *   See the file COPYING.LIB
  *
- * Copyright (c) 1997 - 2002 Kungliga Tekniska H�gskolan (Royal Institute of
+ * Copyright (c) 1997 - 2002 Kungliga Tekniska Högskolan (Royal Institute of
  * Technology, Stockholm, Sweden). All rights reserved.
  *
  *

--- a/plugins/gssapi/gssTunnel.h
+++ b/plugins/gssapi/gssTunnel.h
@@ -2,8 +2,8 @@
  *       Copyright (c) 2000,2001,2002 DESY Hamburg DMG-Division
  *               All rights reserved.
  *
- *       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
- *                 DESY Hamburg DMG-Division
+ *   This program can be distributed under the terms of the GNU LGPL.
+ *   See the file COPYING.LIB
  */
 
 #ifndef GSS_IO_TUNNEL_H

--- a/plugins/gssapi/tunnelQueue.c
+++ b/plugins/gssapi/tunnelQueue.c
@@ -2,8 +2,8 @@
  *       Copyright (c) 2000,2001,2002 DESY Hamburg DMG-Division
  *               All rights reserved.
  *
- *       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
- *                 DESY Hamburg DMG-Division
+ *   This program can be distributed under the terms of the GNU LGPL.
+ *   See the file COPYING.LIB
  */
 #include "tunnelQueue.h"
 #include <stdlib.h>

--- a/plugins/gssapi/tunnelQueue.h
+++ b/plugins/gssapi/tunnelQueue.h
@@ -2,8 +2,8 @@
  *       Copyright (c) 2000,2001,2002 DESY Hamburg DMG-Division
  *               All rights reserved.
  *
- *       THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF
- *                 DESY Hamburg DMG-Division
+ *   This program can be distributed under the terms of the GNU LGPL.
+ *   See the file COPYING.LIB
  */
 #ifndef TUNNEL_QUEUE_H
 #define TUNNEL_QUEUE_H


### PR DESCRIPTION
This PR replaces the "THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE" statement with "This program can be distributed under the terms of the GNU LGPL." used elsewhere in the code.

This follows @kofemann 's comment to https://github.com/dCache/dcap/issues/23#issuecomment-1398457257.

