### PR TITLE
Add missing #include <crypt.h>

### DIFF
--- a/plugins/telnet/dcapPasswd.c
+++ b/plugins/telnet/dcapPasswd.c
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <stdlib.h>
+#include <crypt.h>
 
 int main (int argn, char **argv) {
   int valid_change;


### PR DESCRIPTION
```
dcapPasswd.c:35:34: error: implicit declaration of function 'crypt' [-Werror=implicit-function-declaration]
   35 |       strncpy(savepasswd, (char*)crypt(newpasswd, user), 100);
      |                                  ^~~~~
```
