### PR TITLE
Time 64 bit on 32 bit systems - debian compiling issue.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -117,7 +117,7 @@ dcap_preload64.c
 library_includedir="$(includedir)"
 
 
-AM_CPPFLAGS = -I$(includedir) -DLOCALEDIR=\"$(localedir)\"
+AM_CPPFLAGS = -I$(includedir) -DLOCALEDIR=\"$(localedir)\" -DDCAP_BUILD
 
 
 

--- a/src/dcap.h
+++ b/src/dcap.h
@@ -47,7 +47,7 @@
 extern "C" {
 #endif
 
-#if defined(_FILE_OFFSET_BITS) &&  _FILE_OFFSET_BITS == 64
+#if !defined(DCAP_BUILD) && defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64
 
 #define dc_lseek    dc_lseek64
 #define dc_stat     dc_stat64

--- a/src/dcap_preload.c
+++ b/src/dcap_preload.c
@@ -14,6 +14,14 @@
 /*
  * $Id: dcap_preload.c,v 1.39 2006-09-26 07:47:27 tigran Exp $
  */
+
+#ifdef _FILE_OFFSET_BITS
+#undef _FILE_OFFSET_BITS
+#endif
+#ifdef _TIME_BITS
+#undef _TIME_BITS
+#endif
+
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <fcntl.h>

--- a/src/dcap_test.c
+++ b/src/dcap_test.c
@@ -380,15 +380,15 @@ void print_stat_info( struct stat *s)
     gr = getgrgid(s->st_gid);
     mode2string(s->st_mode, mode);
     printf("dc_stat result:\n");
-    printf("st_ino:     %ld\n", s->st_ino);
+    printf("st_ino:     %llu\n", (unsigned long long) s->st_ino);
     printf("st_dev:     %lu\n", (unsigned long) s->st_dev);
     printf("st_mode:    %s (0%o)\n", mode, s->st_mode);
     printf("st_nlink:   %lu\n", (unsigned long) s->st_nlink);
     printf("st_uid:     %s (%d)\n", pw == NULL ? "unknown" : pw->pw_name,  s->st_uid);
     printf("st_gid:     %s (%d)\n", gr == NULL? "unknown": gr->gr_name, s->st_gid);
-    printf("st_size:    %lu\n", (unsigned long) s->st_size);
+    printf("st_size:    %llu\n", (unsigned long long) s->st_size);
     printf("st_blksize: %ld\n", s->st_blksize);
-    printf("st_blocks:  %ld\n", s->st_blocks);
+    printf("st_blocks:  %lld\n", (long long) s->st_blocks);
     printf("st_atime:   %s", ctime(&s->st_atime));
     printf("st_mtime:   %s", ctime(&s->st_mtime));
     printf("st_ctime:   %s", ctime(&s->st_ctime));

--- a/src/dccp.c
+++ b/src/dccp.c
@@ -409,7 +409,7 @@ int main(int argc, char *argv[])
 	if (rc != -1 )  {
 		copy_time = elapsed_transfer_time(ett_measure);
 		dc_bytes_as_size(formatted_size, size);
-		fprintf(stderr,"%lld bytes (%s) in %lu seconds", (long long)size, formatted_size, copy_time);
+		fprintf(stderr,"%lld bytes (%s) in %lld seconds", (long long) size, formatted_size, (long long) copy_time);
 		if ( copy_time > 0) {
 			dc_bytes_as_size(formatted_rate, (double)size / copy_time);
 			fprintf(stderr," (%s/s)\n", formatted_rate);

--- a/src/wdccp.c
+++ b/src/wdccp.c
@@ -154,7 +154,7 @@ int file2file( const char *source, const char *destination, int overwrite, size_
 			mode = sbuf.st_mode & 0777;
 			/* tell to pool how many bytes we want to write */
 			extracommand[0] = '\0';
-			sprintf(extracommand, "-alloc-size=%ld",sbuf.st_size);
+			sprintf(extracommand, "-alloc-size=%lld", (long long) sbuf.st_size);
 			dc_setExtraOption(extracommand);
 		}
 	}
@@ -231,7 +231,7 @@ int file2file( const char *source, const char *destination, int overwrite, size_
 
 	if (rc != -1 )  {
 		copy_time = endtime-starttime ;
-		fprintf(stderr,"%s => %s: %ld bytes in %lu seconds",source, destination, size, copy_time);
+		fprintf(stderr,"%s => %s: %lld bytes in %lld seconds",source, destination, (long long) size, (long long) copy_time);
 		if ( copy_time > 0) {
 			fprintf(stderr," (%.2f KB/sec)\n",(double)size/(double)(1024*copy_time) );
 		}else{


### PR DESCRIPTION
Debian has enabled 64 bit time_t by default for most of their 32 bit architectures. For dcap this resulted in that the software did not compile. Setting _TIME_BITS=64 is not valid without also setting _FILE_OFFSET_BITS=64.

The macros dc_xxx that redirects to dc_xxx64 that get defined in dcap.h when _FILE_OFFSET_BITS=64 should not be defined when dcap itself is compiled. Not doing this fixes most of the problems.

The remaining issues after that are related to the preload feature. In order not to get multiple definitions of e.g. open64 (and none for open) the preload file for the 32 bit versions must be compiled without _FILE_OFFSET_BITS=64.

With the changes proposed here the compilation succeeds with 64 bit time_t on 32 bit systems.

I didn't try to make the preload wrapper contain both (fstat64, lstat64 and stat64) and (__fstat64_time64, __lstat64_time64, __stat64_time64).
